### PR TITLE
Shrink 'Keep Practicing' button text

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,9 @@
         cursor: pointer;
         text-decoration: none;
       }
+      .cta.cta-sm {
+        font-size: 14px;
+      }
       .cta:hover {
         background: var(--accent-yellow-dark);
       }
@@ -715,7 +718,7 @@
                 </tbody>
               </table>
               <div style="margin-top: 12px">
-                <a href="#practice" data-page="practice" class="cta"
+                <a href="#practice" data-page="practice" class="cta cta-sm"
                   >Keep Practicing</a
                 >
               </div>


### PR DESCRIPTION
## Summary
- add `.cta-sm` class with reduced font size
- apply smaller font to **Keep Practicing** button on Practice Center

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7b5e9b6f883279f673628182a5971