### PR TITLE
Add accent-colored CTAs to dashboard cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,28 @@
         background: var(--accent-yellow-dark);
       }
 
+      .cta.green {
+        background: var(--accent-green);
+        color: #fff;
+      }
+      .cta.green:hover {
+        background: #3aa76c;
+      }
+      .cta.blue {
+        background: var(--accent-blue);
+        color: #fff;
+      }
+      .cta.blue:hover {
+        background: #416da8;
+      }
+      .cta.red {
+        background: var(--accent-red);
+        color: #fff;
+      }
+      .cta.red:hover {
+        background: #b8222f;
+      }
+
       .grid {
         display: grid;
         grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -269,6 +291,14 @@
         border-radius: var(--radius);
         padding: 16px;
         box-shadow: var(--shadow);
+      }
+      #dashboard .card {
+        display: flex;
+        flex-direction: column;
+      }
+      #dashboard .card-action {
+        margin-top: auto;
+        padding-top: 12px;
       }
       .card h2 {
         font-size: 16px;
@@ -352,13 +382,13 @@
       }
       .thumb {
         aspect-ratio: 16/9;
-        background: #eef2ff;
-        border: 1px solid #e5e7eb;
+        background: var(--accent-red);
+        border: 1px solid var(--accent-red);
         border-radius: 12px;
         display: flex;
         align-items: center;
         justify-content: center;
-        color: #547;
+        color: #fff;
         font-weight: 600;
       }
 
@@ -717,7 +747,7 @@
                   </tr>
                 </tbody>
               </table>
-              <div style="margin-top: 12px">
+              <div class="card-action">
                 <a href="#practice" data-page="practice" class="cta cta-sm"
                   >Keep Practicing</a
                 >
@@ -734,6 +764,14 @@
                 <div class="bar r" style="height: 40%"></div>
                 <div class="bar g" style="height: 92%"></div>
                 <div class="bar" style="height: 70%"></div>
+              </div>
+              <div class="card-action">
+                <a
+                  href="#performance"
+                  data-page="performance"
+                  class="cta cta-sm green"
+                  >Check Progress</a
+                >
               </div>
             </div>
 
@@ -754,6 +792,14 @@
                 <div class="meter"><span style="width: 90%"></span></div>
                 <div>90%</div>
               </div>
+              <div class="card-action">
+                <a
+                  href="#learning"
+                  data-page="learning"
+                  class="cta cta-sm blue"
+                  >Take Course</a
+                >
+              </div>
             </div>
 
             <div class="card">
@@ -765,6 +811,14 @@
                 <div class="thumb">Video 4</div>
                 <div class="thumb">Video 5</div>
                 <div class="thumb">Video 6</div>
+              </div>
+              <div class="card-action">
+                <a
+                  href="#content"
+                  data-page="content"
+                  class="cta cta-sm red"
+                  >Check It Out</a
+                >
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Add green, blue, and red CTA button styles
- Insert matching call-to-action buttons for Performance, Learning, and Content cards on dashboard
- Style Content Center tiles with red accent
- Align dashboard card CTAs horizontally with flex layout

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8788c7e0c83278f3e251f4c8ec744