### PR TITLE
Rename Dashboard navigation link to Home

### DIFF
--- a/index.html
+++ b/index.html
@@ -581,7 +581,7 @@
             <svg class="ico" viewBox="0 0 24 24">
               <path d="M3 12l9-7 9 7M5 10v10h14V10" />
             </svg>
-            <span class="label">Dashboard</span>
+            <span class="label">Home</span>
           </a>
           <a href="#practice" data-page="practice">
             <svg class="ico" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- rename Dashboard label to Home in sidebar navigation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8b95d7b008327bf78014f201e66fb