### PR TITLE
Use images for Content Center thumbnails

### DIFF
--- a/assets/placeholder.svg
+++ b/assets/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 225">
+  <rect width="400" height="225" fill="#cccccc"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#666666" font-size="24">No Image</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -338,10 +338,15 @@
       .thumb {
         position: relative;
         aspect-ratio: 16/9;
-        background-size: cover;
-        background-position: center;
         border-radius: 12px;
         overflow: hidden;
+        background-color: #ccc;
+      }
+      .thumb img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
       }
       .thumbs .play-icon {
         font-size: 24px;
@@ -728,45 +733,33 @@
             <div class="card">
               <h2>Content Center</h2>
               <div class="thumbs">
-                <div
-                  class="thumb"
-                  style="background-image:url('https://img.youtube.com/vi/5MgBikgcWnY/maxresdefault.jpg');"
-                >
+                <div class="thumb">
+                  <img src="https://img.youtube.com/vi/5MgBikgcWnY/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
-                <div
-                  class="thumb"
-                  style="background-image:url('https://img.youtube.com/vi/z9Uz1icjwrM/maxresdefault.jpg');"
-                >
+                <div class="thumb">
+                  <img src="https://img.youtube.com/vi/z9Uz1icjwrM/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
-                <div
-                  class="thumb"
-                  style="background-image:url('https://img.youtube.com/vi/2Xc9gXyf2G4/maxresdefault.jpg');"
-                >
+                <div class="thumb">
+                  <img src="https://img.youtube.com/vi/2Xc9gXyf2G4/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
-                <div
-                  class="thumb"
-                  style="background-image:url('https://img.youtube.com/vi/HVsySz-h9r4/maxresdefault.jpg');"
-                >
+                <div class="thumb">
+                  <img src="https://img.youtube.com/vi/HVsySz-h9r4/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
-                <div
-                  class="thumb"
-                  style="background-image:url('https://img.youtube.com/vi/3fumBcKC6RE/maxresdefault.jpg');"
-                >
+                <div class="thumb">
+                  <img src="https://img.youtube.com/vi/3fumBcKC6RE/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
-                <div
-                  class="thumb"
-                  style="background-image:url('https://img.youtube.com/vi/l-gQLqv9f4o/maxresdefault.jpg');"
-                >
+                <div class="thumb">
+                  <img src="https://img.youtube.com/vi/l-gQLqv9f4o/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>


### PR DESCRIPTION
## Summary
- replace inline background-image thumb tiles with `<img>` elements
- add object-fit styling and local placeholder fallback

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8bb5b4cec8327875b9692d1445ddd