### PR TITLE
Ensure hamburger remains visible when sidebar expanded

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
         height: 20px;
         border-radius: 6px;
         background: var(--accent-yellow);
+        margin-right: 8px;
       }
       .brand-label {
         white-space: nowrap;
@@ -197,7 +198,7 @@
         color: var(--white);
       }
       .brand-toggle .hamburger {
-        display: none;
+        display: block;
         width: 20px;
         height: 20px;
         stroke: currentColor;
@@ -206,9 +207,6 @@
       }
       body.sidebar-collapsed .brand-toggle .brand-mark {
         display: none;
-      }
-      body.sidebar-collapsed .brand-toggle .hamburger {
-        display: block;
       }
       .topbar .ico {
         width: 20px;


### PR DESCRIPTION
## Summary
- Keep sidebar hamburger icon visible in expanded state by removing display:none rule
- Add spacing to brand mark so hamburger and logo align cleanly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68a8bdfa5e1c832796187bdde970d08b