### PR TITLE
Use local thumbnails for content center

### DIFF
--- a/index.html
+++ b/index.html
@@ -766,32 +766,32 @@
               <h2>Content Center</h2>
               <div class="thumbs">
                 <div class="thumb">
-                  <img src="https://img.youtube.com/vi/5MgBikgcWnY/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
+                  <img src="assets/Thumbnail1.png" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
                 <div class="thumb">
-                  <img src="https://img.youtube.com/vi/z9Uz1icjwrM/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
+                  <img src="assets/Thumbnail2.png" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
                 <div class="thumb">
-                  <img src="https://img.youtube.com/vi/2Xc9gXyf2G4/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
+                  <img src="assets/Thumbnail3.png" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
                 <div class="thumb">
-                  <img src="https://img.youtube.com/vi/HVsySz-h9r4/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
+                  <img src="assets/Thumbnail4.png" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
                 <div class="thumb">
-                  <img src="https://img.youtube.com/vi/3fumBcKC6RE/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
+                  <img src="assets/Thumbnail5.png" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
                 <div class="thumb">
-                  <img src="https://img.youtube.com/vi/l-gQLqv9f4o/maxresdefault.jpg" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
+                  <img src="assets/Thumbnail6.png" alt="Video thumbnail" onerror="this.src='assets/placeholder.svg';" />
                   <div class="resource-type">Video</div>
                   <div class="play-icon">▶</div>
                 </div>
@@ -1009,7 +1009,7 @@
           <div class="content-grid">
             <!-- Video -->
             <div class="resource-card">
-              <div class="resource-thumb" style="background-image:url('https://img.youtube.com/vi/5MgBikgcWnY/maxresdefault.jpg');">
+              <div class="resource-thumb" style="background-image:url('assets/Thumbnail1.png');">
                 <div class="resource-type">Video</div>
                 <div class="play-icon">▶</div>
               </div>
@@ -1021,7 +1021,7 @@
         
             <!-- Video -->
             <div class="resource-card">
-              <div class="resource-thumb" style="background-image:url('https://img.youtube.com/vi/z9Uz1icjwrM/maxresdefault.jpg');">
+              <div class="resource-thumb" style="background-image:url('assets/Thumbnail2.png');">
                 <div class="resource-type">Video</div>
                 <div class="play-icon">▶</div>
               </div>
@@ -1045,7 +1045,7 @@
         
             <!-- Video -->
             <div class="resource-card">
-              <div class="resource-thumb" style="background-image:url('https://img.youtube.com/vi/2Xc9gXyf2G4/maxresdefault.jpg');">
+              <div class="resource-thumb" style="background-image:url('assets/Thumbnail3.png');">
                 <div class="resource-type">Video</div>
                 <div class="play-icon">▶</div>
               </div>
@@ -1057,7 +1057,7 @@
         
             <!-- Video -->
             <div class="resource-card">
-              <div class="resource-thumb" style="background-image:url('https://img.youtube.com/vi/HVsySz-h9r4/maxresdefault.jpg');">
+              <div class="resource-thumb" style="background-image:url('assets/Thumbnail4.png');">
                 <div class="resource-type">Video</div>
                 <div class="play-icon">▶</div>
               </div>


### PR DESCRIPTION
## Summary
- Replace dashboard Content Center thumbnails with local assets
- Update Content Center resource thumbnails to use local images

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ae1ddb56f88327864bcb25107c8448