### PR TITLE
Use local images for Learning Center courses

### DIFF
--- a/index.html
+++ b/index.html
@@ -951,7 +951,7 @@
             <!-- Card 1 -->
             <div class="card course-card">
               <div class="course-thumb"
-                   style="background-image:url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=60');">
+                   style="background-image:url('assets/EXTRA-Facilitating%20buyin.jpg');">
                 <div class="course-title-on-thumb">Managing a Consulting Client</div>
               </div>
               <div class="course-body">
@@ -966,7 +966,7 @@
             <!-- Card 2 -->
             <div class="card course-card">
               <div class="course-thumb"
-                   style="background-image:url('https://images.unsplash.com/photo-1515187029135-18ee286d815b?auto=format&fit=crop&w=1200&q=60');">
+                   style="background-image:url('assets/EXTRA-Identifying%20Risk.jpg');">
                 <div class="course-title-on-thumb">Consultant's Tool Kit</div>
               </div>
               <div class="course-body">
@@ -981,7 +981,7 @@
             <!-- Card 3 -->
             <div class="card course-card">
               <div class="course-thumb"
-                   style="background-image:url('https://images.unsplash.com/photo-1537432376769-00a099ff7f26?auto=format&fit=crop&w=1200&q=60');">
+                   style="background-image:url('assets/EXTRA-Managing%20a%20consultant.jpg');">
                 <div class="course-title-on-thumb">Managing Projects in a Consulting Environment</div>
               </div>
               <div class="course-body">


### PR DESCRIPTION
## Summary
- replace Unsplash course thumbnails with local images in assets

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae2206a114832782a5ca5d1cd23944