### PR TITLE
style: update CTA button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,13 +552,13 @@
 /* shared button base */
 .cta{
   display:inline-flex; align-items:center; justify-content:center;
-  height:44px; padding:0 14px; border-radius:10px; font-weight:700;
+  height:44px; padding:0 24px; border-radius:9999px; font-weight:700;
   text-decoration:none; white-space:nowrap;      /* prevent wrapping */
   flex:1;                                        /* equal widths */
-  background:var(--accent-yellow); color:#111; border:none;
+  background:var(--primary); color:#fff; border:4px solid var(--accent-yellow);
 }
-.cta:hover{ background:var(--accent-yellow-dark); }
-.cta.cta-sm{ font-size:14px; }
+.cta:hover{ background:var(--primary); filter:brightness(1.1); border:4px solid var(--accent-yellow); }
+.cta.cta-sm{ font-size:14px; height:36px; padding:0 18px; }
 /* --- Content Center --- */
 .content-grid {
   display:grid;


### PR DESCRIPTION
## Summary
- refresh shared CTA styles with navy background, orange border, and pill shape
- lighten CTA hover state and ensure small variant keeps new theme

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68ae29dd8ee4832785109984c6bb74e6