### PR TITLE
Make hamburger icon stroke white

### DIFF
--- a/index.html
+++ b/index.html
@@ -673,7 +673,7 @@
               <rect width="24" height="24" rx="6" fill="var(--accent-yellow)" />
               <path
                 d="M4 6h16M4 12h16M4 18h16"
-                stroke="#1f2937"
+                stroke="var(--white)"
                 stroke-width="2"
                 fill="none"
               />


### PR DESCRIPTION
## Summary
- make hamburger menu lines white via `var(--white)`

## Testing
- `npm test` *(fails: Missing script)*
- `node - <<'NODE'
function contrast(hex1, hex2) {
  function luminance(hex) {
    const r = parseInt(hex.slice(1,3),16)/255;
    const g = parseInt(hex.slice(3,5),16)/255;
    const b = parseInt(hex.slice(5,7),16)/255;
    const channels = [r,g,b].map(c => c <= 0.03928 ? c/12.92 : Math.pow((c+0.055)/1.055,2.4));
    const [R,G,B] = channels;
    return 0.2126*R + 0.7152*G + 0.0722*B;
  }
  const L1 = luminance(hex1);
  const L2 = luminance(hex2);
  const ratio = (Math.max(L1,L2) + 0.05)/(Math.min(L1,L2) + 0.05);
  return ratio;
}
console.log('contrast ratio', contrast('#ffffff','#f29d23'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68ae2a021acc83279ab477af6f316b13