### PR TITLE
feat: orange hover for hero buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -562,7 +562,11 @@
   flex:1;                                        /* equal widths */
   background:var(--primary); color:#fff; border:3px solid var(--accent-yellow);
 }
-.cta:hover{ background:var(--primary); filter:brightness(1.1); border:3px solid var(--accent-yellow); }
+.cta:hover{
+  background:var(--accent-yellow);
+  color:var(--white);
+  border:3px solid var(--accent-yellow);
+}
 .cta.cta-sm{ font-size:14px; height:36px; padding:0 18px; }
 /* --- Content Center --- */
 .content-grid {


### PR DESCRIPTION
## Summary
- swap hero button hover styles to display an orange background with white text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f82b6d083278b919d9f3a32b431