### PR TITLE
style: highlight overview call-to-action

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,6 +568,8 @@
   border:3px solid var(--accent-yellow);
 }
 .cta.cta-sm{ font-size:14px; height:36px; padding:0 18px; }
+.cta.overview{background:var(--accent-yellow);color:#fff;border:3px solid var(--accent-yellow);}
+.cta.overview:hover{background:var(--accent-yellow-dark);}
 /* --- Content Center --- */
 .content-grid {
   display:grid;
@@ -1035,7 +1037,7 @@
               <div class="course-body">
                 <div class="progress">0% complete</div>
                 <div class="btn-row card-action">
-                  <a href="#" class="cta cta-sm">See Overview</a>
+                  <a href="#" class="cta cta-sm overview">See Overview</a>
                   <a href="#" class="cta cta-sm">Start Course</a>
                 </div>
               </div>
@@ -1050,7 +1052,7 @@
               <div class="course-body">
                 <div class="progress">68% complete</div>
                 <div class="btn-row card-action">
-                  <a href="#" class="cta cta-sm">See Overview</a>
+                  <a href="#" class="cta cta-sm overview">See Overview</a>
                   <a href="#" class="cta cta-sm">Resume Course</a>
                 </div>
               </div>
@@ -1065,7 +1067,7 @@
               <div class="course-body">
                 <div class="progress">93% complete</div>
                 <div class="btn-row card-action">
-                  <a href="#" class="cta cta-sm">See Overview</a>
+                  <a href="#" class="cta cta-sm overview">See Overview</a>
                   <a href="#" class="cta cta-sm">Resume Course</a>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add orange-themed overview modifier for CTA buttons
- apply overview style to each "See Overview" button

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68ae324549948327aacbbfc5d4247c7c