### PR TITLE
style: restyle See Overview button

### DIFF
--- a/index.html
+++ b/index.html
@@ -573,8 +573,8 @@
   border:3px solid var(--accent-yellow);
 }
 .cta.cta-sm{ font-size:14px; height:36px; padding:0 18px; }
-.cta.overview{background:var(--accent-yellow);color:#fff;border:3px solid var(--accent-yellow);}
-.cta.overview:hover{background:var(--accent-yellow-dark);}
+.cta.overview{background:var(--white);color:var(--primary);border:3px solid var(--accent-yellow);}
+.cta.overview:hover{background:var(--accent-yellow);color:var(--white);border:3px solid var(--accent-yellow);}
 /* --- Content Center --- */
 .content-grid {
   display:grid;


### PR DESCRIPTION
## Summary
- Restyle "See Overview" button with orange outline, white background, and navy text
- Apply standard hover behavior to "See Overview" button

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae35d87c38832790709cbc46a38724