### PR TITLE
Ensure team charts redraw on window resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -1607,10 +1607,12 @@
           );
       }
 
-      // Redraw on resize (if on Performance)
+      // Redraw on resize (if on Performance or Team)
       window.addEventListener("resize", () => {
         if (document.querySelector("#performance.page.active"))
           requestAnimationFrame(drawAllCharts);
+        if (document.querySelector("#team.page.active"))
+          requestAnimationFrame(drawTeamCharts);
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- Redraw team charts when the window resizes and team page is active

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae37e2f86483279a91db31d259d0e5