### PR TITLE
chore: darken yellow accent

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       :root {
         --primary: #12203a;
         --accent-yellow: #f29d23;
-        --accent-yellow-dark: #f29d0e;
+        --accent-yellow-dark: #C77F0B;
         --accent-green: #42ba7d;
         --accent-red: #cc2836;
         --accent-blue: #5280bc;


### PR DESCRIPTION
## Summary
- darken `--accent-yellow-dark` for better contrast
- check for other uses of `--accent-yellow-dark` but none found

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae38393fb08327b00b76d1278922ef