### PR TITLE
Add responsive card grid to Team Dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -657,16 +657,15 @@
         text-decoration: underline;
         font-size: 14px;
       }
-      .kpi-grid {
+      #team .card-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-        gap: 16px;
-        margin-bottom: 20px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 18px;
       }
-      .kpi-grid .kpi {
-        font-size: 28px;
-        font-weight: 700;
-        margin-top: 4px;
+      @media (max-width: 980px) {
+        #team .card-grid {
+          grid-template-columns: 1fr;
+        }
       }
       #team .card canvas {
         width: 100%;
@@ -1188,44 +1187,49 @@
             </select>
             <a href="#" class="link-like">Reset</a>
           </div>
-          <div class="kpi-grid">
+          <div class="card-grid">
             <div class="card">
-              <h2>Total Members</h2>
-              <div class="kpi">24</div>
+              <h2>Certifications Summary</h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Certification</th>
+                    <th>Members</th>
+                    <th>Completed</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>AWS</td><td>10</td><td>7</td></tr>
+                  <tr><td>Azure</td><td>8</td><td>5</td></tr>
+                  <tr><td>GCP</td><td>6</td><td>4</td></tr>
+                </tbody>
+              </table>
             </div>
             <div class="card">
-              <h2>Active</h2>
-              <div class="kpi">18</div>
+              <h2>Practice Activity &amp; Scores</h2>
+              <canvas id="teamComboChart"></canvas>
             </div>
-            <div class="card">
-              <h2>Pending</h2>
-              <div class="kpi">6</div>
+            <div class="card" style="grid-column: 1 / -1">
+              <h2>Course Progress</h2>
+              <canvas id="teamStacked"></canvas>
             </div>
-          </div>
-          <div class="card wide">
-            <h2>Performance Overview</h2>
-            <canvas id="teamComboChart"></canvas>
-          </div>
-          <div class="card wide">
-            <h2>Skill Progress</h2>
-            <canvas id="teamStacked"></canvas>
-          </div>
-          <div class="card">
-            <h2>Team Details</h2>
-            <table>
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Role</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr><td>Ada Lovelace</td><td>Consultant</td><td>Active</td></tr>
-                <tr><td>Grace Hopper</td><td>Manager</td><td>Active</td></tr>
-                <tr><td>Alan Turing</td><td>Analyst</td><td>Pending</td></tr>
-              </tbody>
-            </table>
+            <div class="card" style="grid-column: 1 / -1">
+              <h2>Team Details</h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Role</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr><td>Ada Lovelace</td><td>Consultant</td><td>Active</td></tr>
+                  <tr><td>Grace Hopper</td><td>Manager</td><td>Active</td></tr>
+                  <tr><td>Alan Turing</td><td>Analyst</td><td>Pending</td></tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Replace KPI widgets with grid layout of four cards on Team Dashboard
- Style new card grid with responsive breakpoints

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")

------
https://chatgpt.com/codex/tasks/task_e_68ae3a598d608327a5f4ea9bff49f50b