### PR TITLE
Reduce sidebar brand padding to reveal logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,8 +105,8 @@
       .brand {
         display: flex;
         align-items: center;
-        gap: 8px;
-        padding: 22px 24px;
+        gap: 6px;
+        padding: 22px 24px 22px 12px;
         font-weight: 700;
         letter-spacing: 0.2px;
       }


### PR DESCRIPTION
## Summary
- Decrease `.brand` left padding and gap to prevent logo overflow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae42ea15808327b42d417275fcbfbe