### PR TITLE
Use #F29D0E as primary accent color

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <style>
       :root {
         --primary: #12203a;
-        --accent-yellow: #f29d0e;
-        --accent-yellow-dark: #f29d23;
+        --accent-yellow: #F29D0E;
+        --accent-yellow-dark: #F29D0E;
         --accent-green: #42ba7d;
         --accent-red: #cc2836;
         --accent-blue: #5280bc;
@@ -1413,7 +1413,7 @@
       const BRAND = {
         blue: "#5280BC",
         green: "#42BA7D",
-        yellow: "#F29D23",
+        yellow: "#F29D0E",
         red: "#CC2836",
         grid: "#EEF2F7",
         axis: "#E5E7EB",


### PR DESCRIPTION
## Summary
- Ensure `--accent-yellow` is `#F29D0E`
- Align `BRAND.yellow` with `#F29D0E`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae4f6bb6a08327b17d9d536fcd5a1b