### PR TITLE
Reorder sidebar logo and update toggle icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
       .brand-toggle {
         padding: 0;
         background: none;
-        color: var(--white);
+        color: var(--accent-yellow);
       }
       .brand-toggle .hamburger {
         display: block;
@@ -701,6 +701,7 @@
       <!-- Sidebar -->
       <aside class="sidebar">
         <div class="brand">
+          <img src="assets/TCW Logo White.png" alt="The Consultant's Way" class="brand-logo" />
           <button
             id="collapseBtnSidebar"
             class="brand-toggle"
@@ -708,16 +709,15 @@
             title="Toggle sidebar"
           >
             <svg class="hamburger" viewBox="0 0 24 24" aria-hidden="true">
-              <rect width="24" height="24" rx="6" fill="var(--accent-yellow)" />
               <path
-                d="M4 6h16M4 12h16M4 18h16"
-                stroke="var(--white)"
+                d="M2 6h20M2 12h20M2 18h20"
+                stroke="var(--accent-yellow)"
                 stroke-width="2"
                 fill="none"
+                stroke-linecap="round"
               />
             </svg>
           </button>
-          <img src="assets/TCW Logo White.png" alt="The Consultant's Way" class="brand-logo" />
         </div>
         <nav class="nav">
           <a href="#dashboard" data-page="dashboard" class="active">


### PR DESCRIPTION
## Summary
- Show platform logo before sidebar collapse button
- Use accent-yellow strokes for hamburger menu icon without background
- Tint sidebar toggle button with accent-yellow

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae540e79bc832793632f46f49edc1f