### PR TITLE
Ensure line dataset draws above bars in team chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -1752,6 +1752,7 @@
                 },
                 {
                   type: "line",
+                  order: 2,
                   label: "Avg Score",
                   data: avgScoreArray,
                   borderColor: style.getPropertyValue("--primary").trim(),


### PR DESCRIPTION
## Summary
- ensure line dataset in `drawTeamCharts` renders above bars by assigning `order: 2`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae5476c560832797bad86014fc81e3