### PR TITLE
Increase sidebar width to prevent hamburger icon clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         --card: #ffffff;
         --shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
         --radius: 14px;
-        --sidebar: 240px; /* collapsible width */
+        --sidebar: 260px; /* collapsible width */
       }
 
       * {


### PR DESCRIPTION
## Summary
- widen default sidebar from 240px to 260px
- keep layout and collapsed width driven by CSS variable `--sidebar`

## Testing
- `npm start >/tmp/server.log 2>&1 &`
- `curl -sL http://localhost:5000/index | head`
- `curl -sL http://localhost:5000/index | rg -- '--sidebar:'`


------
https://chatgpt.com/codex/tasks/task_e_68ae558d61a0832790b1139a86dc3699