### PR TITLE
Disable chart hover interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -1735,6 +1735,9 @@
           ];
           const practicesArray = [17, 12, 15, 9, 11, 18];
           const avgScoreArray = [86, 78, 92, 81, 74, 95];
+          const barColor = style.getPropertyValue("--accent-yellow").trim();
+          const pointColor = "#fff";
+          const radius = 4;
 
           new Chart(combo, {
             type: "bar",
@@ -1744,15 +1747,9 @@
                 {
                   label: "Practices",
                   data: practicesArray,
-                  backgroundColor: style
-                    .getPropertyValue("--accent-yellow")
-                    .trim(),
-                  hoverBackgroundColor: style
-                    .getPropertyValue("--accent-yellow")
-                    .trim(),
-                  hoverBorderColor: style
-                    .getPropertyValue("--accent-yellow")
-                    .trim(),
+                  backgroundColor: barColor,
+                  hoverBackgroundColor: barColor,
+                  hoverBorderColor: barColor,
                   borderRadius: 6,
                   yAxisID: "y",
                 },
@@ -1765,16 +1762,17 @@
                   backgroundColor: style.getPropertyValue("--primary").trim(),
                   yAxisID: "y1",
                   tension: 0.4,
-                  pointRadius: 4,
-                  pointHoverRadius: 4,
-                  pointBackgroundColor: "#fff",
-                  pointHoverBackgroundColor: "#fff",
+                  pointRadius: radius,
+                  pointHoverRadius: radius,
+                  pointBackgroundColor: pointColor,
+                  pointHoverBackgroundColor: pointColor,
                   pointBorderColor: style.getPropertyValue("--primary").trim(),
                 },
               ],
             },
             options: {
               maintainAspectRatio: false,
+              interaction: { mode: null },
               hover: { mode: null },
               scales: {
                 x: { type: "category", offset: true },


### PR DESCRIPTION
## Summary
- Disable hover and interaction modes for the team combo chart so bars and points don't highlight
- Ensure bar dataset maintains the same color on hover
- Keep line chart points consistent on hover by matching radius and background color

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae570ac6d88327b4f813bacc1e553a