### PR TITLE
Expand sidebar width for brand visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         --card: #ffffff;
         --shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
         --radius: 14px;
-        --sidebar: 260px; /* collapsible width */
+        --sidebar: 275px; /* collapsible width */
       }
 
       * {


### PR DESCRIPTION
## Summary
- widen sidebar to 275px so logo and menu toggle fit without clipping

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start` then `curl -s http://localhost:5000/ | rg --line-number -- '--sidebar'`

------
https://chatgpt.com/codex/tasks/task_e_68ae58506b348327bb5be97a12a9188e