### PR TITLE
fix: limit brand logo width

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
         color: #fff;
       }
       .brand-logo {
-        max-width: 100%;
+        max-width: 190px;
         max-height: 36px;
         height: auto;
       }


### PR DESCRIPTION
## Summary
- constrain brand logo to 190px max width to ensure hamburger icon visibility in expanded sidebar

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68ae5ab05a2c8327951e8b66ee8e7fa5