### PR TITLE
Reuse team chart instance in team view

### DIFF
--- a/index.html
+++ b/index.html
@@ -1408,6 +1408,8 @@
           // If currently on Performance, redraw to fit new width
           if (document.querySelector("#performance.page.active"))
             requestAnimationFrame(drawAllCharts);
+          if (document.querySelector("#team.page.active"))
+            requestAnimationFrame(drawTeamCharts);
         });
 
       // ---- Tiny chart drawer (Canvas 2D) ----
@@ -1720,10 +1722,13 @@
       }
 
       // Draw Practice Activity combo chart and Course Progress bars
+      let teamComboChartInstance;
+
       function drawTeamCharts() {
         const combo = document.getElementById("teamComboChart");
         const stacked = document.getElementById("teamStacked");
         if (combo) {
+          if (teamComboChartInstance) teamComboChartInstance.destroy();
           const style = getComputedStyle(document.documentElement);
           const labels = [
             "Week 12",
@@ -1739,7 +1744,7 @@
           const pointColor = "#fff";
           const radius = 4;
 
-          new Chart(combo, {
+          teamComboChartInstance = new Chart(combo, {
             type: "bar",
             data: {
               labels,


### PR DESCRIPTION
## Summary
- track the team combo chart instance so repeated renders destroy the prior chart
- ensure sidebar collapse and resize trigger team chart redraw

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae5c78ed9083278973b455edebc85f