### PR TITLE
Align sidebar brand toggle with navigation items

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,8 @@
         display: flex;
         align-items: center;
         gap: 6px;
-        padding: 22px 24px 22px 12px;
+        padding: 22px 12px;
+        padding-right: 24px;
         font-weight: 700;
         letter-spacing: 0.2px;
       }
@@ -206,6 +207,7 @@
         background: #e5e7eb;
       }
       .brand-toggle {
+        margin-left: auto;
         padding: 0;
         background: none;
         color: var(--accent-yellow);


### PR DESCRIPTION
## Summary
- adjust sidebar brand layout to flex with explicit right padding
- push brand toggle hamburger to the right using margin auto

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start` *(serve: INFO Accepting connections at http://localhost:5000)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5c8d876c8327ac9d8e0ff750e8a6