### PR TITLE
Center collapsed brand toggle in sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,11 @@
         display: none;
       }
       body.sidebar-collapsed .brand {
-        padding: 18px 16px;
+        padding: 0;                /* remove asymmetric padding */
+        justify-content: center;   /* center contents */
+      }
+      body.sidebar-collapsed .brand-toggle {
+        margin-left: 0;            /* cancel auto margin */
       }
       body.sidebar-collapsed .nav a,
       body.sidebar-collapsed .admin-link {


### PR DESCRIPTION
## Summary
- Center collapsed brand header contents and remove extra padding
- Cancel auto-margin on collapsed brand toggle so hamburger aligns with icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start` *(Accepting connections at http://localhost:5000)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5e3e9910832796ca016a5c8e4e51