### PR TITLE
Add navigation link tooltips for collapsed sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,13 +722,13 @@
           </button>
         </div>
         <nav class="nav">
-          <a href="#dashboard" data-page="dashboard" class="active">
+          <a href="#dashboard" data-page="dashboard" class="active" title="Home" aria-label="Home">
             <svg class="ico" viewBox="0 0 24 24">
               <path d="M3 12l9-7 9 7M5 10v10h14V10" />
             </svg>
             <span class="label">Home</span>
           </a>
-          <a href="#practice" data-page="practice">
+          <a href="#practice" data-page="practice" title="Practice Center" aria-label="Practice Center">
             <svg class="ico" viewBox="0 0 24 24">
               <circle cx="12" cy="12" r="9" />
               <circle cx="12" cy="12" r="5" />
@@ -736,19 +736,19 @@
             </svg>
             <span class="label">Practice Center</span>
           </a>
-          <a href="#performance" data-page="performance">
+          <a href="#performance" data-page="performance" title="Performance Center" aria-label="Performance Center">
             <svg class="ico" viewBox="0 0 24 24">
               <path d="M4 20h16M6 20V14h3v6H6ZM11 20V10h3v10h-3ZM16 20V5h3v15h-3Z" />
             </svg>
             <span class="label">Performance Center</span>
           </a>
-          <a href="#learning" data-page="learning">
+          <a href="#learning" data-page="learning" title="Learning Center" aria-label="Learning Center">
             <svg class="ico" viewBox="0 0 24 24">
               <path d="M3 7l9-4 9 4-9 4-9-4M6 10v7l6 3 6-3v-7" />
             </svg>
             <span class="label">Learning Center</span>
           </a>
-          <a href="#content" data-page="content">
+          <a href="#content" data-page="content" title="Content Center" aria-label="Content Center">
             <svg class="ico" viewBox="0 0 24 24">
               <path d="M5 5h14v14H5zM10 8l6 4-6 4z" />
             </svg>


### PR DESCRIPTION
## Summary
- add title and aria-label attributes to sidebar navigation links so icons show tooltips when collapsed

## Testing
- `timeout 5 npm start`


------
https://chatgpt.com/codex/tasks/task_e_68ae5fe02c208327916730c119ab7e41