### PR TITLE
Add dataset order to team combo chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -1753,6 +1753,7 @@
               datasets: [
                 {
                   label: "Practices",
+                  order: 1,
                   data: practicesArray,
                   backgroundColor: barColor,
                   hoverBackgroundColor: barColor,


### PR DESCRIPTION
## Summary
- Render combo chart bars before line by assigning `order: 1` to the bar dataset and keeping the line dataset order higher.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae612ed5788327840c2b628084eab6