### PR TITLE
Add Chart.js DataLabels plugin to team combo chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -1368,6 +1368,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels"></script>
     <script>
       // ---- Routing (works for nav, topbar, and any [data-page]) ----
       function wireDataPageLinks(scope = document) {
@@ -1777,6 +1778,7 @@
                 },
               ],
             },
+            plugins: [ChartDataLabels],
             options: {
               maintainAspectRatio: false,
               interaction: { mode: null },
@@ -1800,6 +1802,10 @@
                         ctx.dataset.type === "line" ? "%" : ""
                       }`,
                   },
+                },
+                datalabels: {
+                  align: "top",
+                  formatter: (value) => value,
                 },
               },
             },


### PR DESCRIPTION
## Summary
- load Chart.js DataLabels plugin via CDN and register it in team chart
- configure team combo chart to display top-aligned data labels

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae613c22208327871a33f866bea14b