### PR TITLE
Add Performance Management admin page

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,6 +643,33 @@
         color: #fff;
       }
 
+      /* --- Performance Management --- */
+      #performance-management .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 18px;
+      }
+      @media (max-width: 880px) {
+        #performance-management .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+      #performance-management .card {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        gap: 16px;
+      }
+      #performance-management .card .icon {
+        width: 48px;
+        height: 48px;
+        stroke: currentColor;
+        stroke-width: 1.8;
+        fill: none;
+      }
+
       /* --- Team Dashboard --- */
       #team .filters-row {
         display: flex;
@@ -765,6 +792,12 @@
               <path d="M9 13h6" />
             </svg>
             <span class="label">Team Dashboard</span>
+          </a>
+          <a href="#performance-management" data-page="performance-management" class="admin-link">
+            <svg class="ico" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"/>
+            </svg>
+            <span class="label">Performance Management</span>
           </a>
         </div>
       </aside>
@@ -1355,6 +1388,25 @@
                   </tbody>
                 </table>
               </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- PERFORMANCE MANAGEMENT -->
+        <section id="performance-management" class="page">
+          <h1>Performance Management</h1>
+          <div class="grid">
+            <div class="card">
+              <svg class="icon" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"/>
+              </svg>
+              <button class="cta">Complete an Employee Review</button>
+            </div>
+            <div class="card">
+              <svg class="icon" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z"/>
+              </svg>
+              <button class="cta">Create/Edit Development Plans</button>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add Performance Management link in admin sidebar
- create Performance Management page with two action cards
- style page layout and icons

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0729c81c083279c220054b93410f5