### PR TITLE
Rename Team Home to Team Dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -791,7 +791,7 @@
               <path d="M9 9h6" />
               <path d="M9 13h6" />
             </svg>
-            <span class="label">Team Home</span>
+            <span class="label">Team Dashboard</span>
           </a>
           <a href="#performance-management" data-page="performance-management" class="admin-link">
             <svg class="ico" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- Rename admin nav link from "Team Home" to "Team Dashboard"

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b07486394c8327b83fab7345869a34