### PR TITLE
feat: expand objectives table

### DIFF
--- a/index.html
+++ b/index.html
@@ -864,18 +864,37 @@
               </thead>
               <tbody>
                 <tr>
-                  <td class="category">🎯 Yearly Goals</td>
+                  <td class="category" rowspan="3">🎯 Yearly Goals</td>
                   <td>Grow strategic account relationships</td>
                   <td><a href="#practice">practice</a>, <a href="#course">course</a></td>
                 </tr>
                 <tr>
-                  <td class="category">✅ Near-Term Priorities</td>
+                  <td>Increase multi-product adoption</td>
+                  <td><a href="#course">course</a></td>
+                </tr>
+                <tr>
+                  <td>Improve customer retention</td>
+                  <td><a href="#practice">practice</a>, <a href="#course">course</a></td>
+                </tr>
+                <tr>
+                  <td class="category" rowspan="3">✅ Near-Term Priorities</td>
                   <td>Master objection handling</td>
                   <td><a href="#practice">practice</a>, <a href="#course">course</a></td>
                 </tr>
+                <tr>
+                  <td>Accelerate onboarding of new hires</td>
+                  <td><a href="#course">course</a></td>
+                </tr>
+                <tr>
+                  <td>Strengthen demo skills</td>
+                  <td><a href="#practice">practice</a></td>
+                </tr>
                 <tr class="smart">
-                  <td class="category">💡 Smart Suggestions</td>
+                  <td class="category" rowspan="2">💡 Smart Suggestions</td>
                   <td colspan="2">Consider a <a href="#practice">practice</a> session on enterprise discovery.</td>
+                </tr>
+                <tr class="smart">
+                  <td colspan="2">Enroll in a <a href="#course">course</a> on competitive analysis.</td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
## Summary
- Expand objectives table with full objective list and recommended paths.
- Use category rowspans and suggestion colspans for clearer layout.

## Testing
- `npm start`
- `curl -Ls http://localhost:5000/index | sed -n '860,900p'`


------
https://chatgpt.com/codex/tasks/task_e_68b076fdb77883278ef17e084718c9d1