### PR TITLE
Remove focus outline from search input

### DIFF
--- a/index.html
+++ b/index.html
@@ -756,6 +756,10 @@
         outline-offset: 2px;
       }
 
+      .search input:focus-visible {
+        outline: none;
+      }
+
       </style>
     </head>
   <body>


### PR DESCRIPTION
## Summary
- prevent orange outline on search bar by overriding focus-visible style

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b07f2910a0832793825d45b413b251