### PR TITLE
Enhance smart suggestion styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,7 +331,16 @@
         font-weight: 700;
       }
       .enablement-objectives tr.smart {
-        background: #fefce8;
+        background: none;
+      }
+      .enablement-objectives tr.smart td:not(.category) {
+        font-style: italic;
+        color: #4b5563;
+      }
+      .enablement-objectives tr.smart td a {
+        color: var(--accent-blue);
+        text-decoration: underline;
+        font-weight: 400;
       }
       .enablement-objectives a {
         color: var(--accent-blue);
@@ -908,7 +917,21 @@
                   </td>
                 </tr>
                 <tr class="smart">
-                  <td class="category" rowspan="2">Smart Suggestions</td>
+                  <td class="category" rowspan="2">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="#F29D23"
+                      style="vertical-align: middle; margin-right: 4px;"
+                    >
+                      <path
+                        d="M12 2a7 7 0 00-7 7c0 2.5 1.5 4.7 3.5 5.8.3.2.5.5.5.9V17c0 .6.4 1 1 1h4a1 1 0 001-1v-1.3c0-.4.2-.7.5-.9A7 7 0 0019 9a7 7 0 00-7-7zm-1 19a1 1 0 102 0h-2z"
+                      />
+                    </svg>
+                    Smart Suggestions
+                  </td>
                   <td colspan="2">
                     Based on your recent course activity,
                     <a href="#practice">practice framing an idea</a>


### PR DESCRIPTION
## Summary
- Remove background color from smart suggestion rows
- Add lightbulb icon and italicized styling for smart suggestions
- Ensure links in smart suggestions are blue, underlined, and lighter weight

## Testing
- ⚠️ `npm test` (missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b08c2a173c8327babb92b6ed32b1cf