### PR TITLE
chore: add objectives header styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,6 +333,9 @@
       .enablement-objectives thead th {
         background: #f9fafb;
       }
+      .enablement-objectives-header {
+        white-space: nowrap;
+      }
       .enablement-objectives .category {
         font-weight: 700;
       }
@@ -883,8 +886,7 @@
             <table>
               <thead>
                 <tr>
-                  <th>Enablement Objectives</th>
-                  <th></th>
+                  <th colspan="2" class="enablement-objectives-header">Enablement Objectives</th>
                   <th>Recommended Path</th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- ensure enablement objectives header spans two columns
- prevent header text wrapping with `enablement-objectives-header`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b09096e8548327a52955bb32c6e41a