### PR TITLE
style: tweak enablement objectives table text

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,9 +326,15 @@
       .enablement-objectives td {
         padding: 6px 8px;
         border-bottom: 1px solid #e5e7eb;
-        font-size: 0.875rem;
         line-height: 1.35;
         text-align: left;
+      }
+      .enablement-objectives th {
+        font-size: 0.875rem;
+      }
+      .enablement-objectives td {
+        font-size: 0.75rem;
+        color: #6b7280;
       }
       .enablement-objectives thead th {
         background: #f9fafb;
@@ -344,15 +350,13 @@
       }
       .enablement-objectives tr.smart td:not(.category) {
         font-style: italic;
-        color: #4b5563;
+        color: #6b7280;
       }
       .enablement-objectives tr.smart td a {
-        color: var(--accent-blue);
-        text-decoration: underline;
         font-weight: 400;
       }
       .enablement-objectives a {
-        color: var(--accent-blue);
+        color: #6b7280;
         text-decoration: underline;
       }
 


### PR DESCRIPTION
## Summary
- Make enablement objectives table body text smaller and use header color

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b091fe921083279105c90f85a5d917