### PR TITLE
style: accent smart suggestions text

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,12 +346,15 @@
       .enablement-objectives .category {
         font-weight: 700;
       }
+      .enablement-objectives tr.smart .category {
+        color: var(--accent-yellow);
+      }
       .enablement-objectives tr.smart {
         background: none;
       }
       .enablement-objectives tr.smart td:not(.category) {
         font-style: italic;
-        color: #6b7280;
+        color: var(--accent-yellow);
       }
       .enablement-objectives tr.smart td a {
         font-weight: 400;
@@ -359,6 +362,9 @@
       .enablement-objectives a {
         color: #6b7280;
         text-decoration: underline;
+      }
+      .enablement-objectives tr.smart a {
+        color: var(--accent-yellow);
       }
 
       .num-cell {


### PR DESCRIPTION
## Summary
- Highlight Smart Suggestions rows with the accent yellow color to match the bulb icon

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b09549bb2483278537e9df709d4e05