### PR TITLE
Switch site to Montserrat font

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>The Consultant's Way — Mock Platform</title>
 
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
     <style>
@@ -38,18 +38,14 @@
         margin: 0;
         background: var(--bg);
         color: var(--text);
-        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-family: "Montserrat", "Helvetica Neue", Helvetica, Arial,
+          sans-serif;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
       }
       h1,
       h2 {
         margin: 0 0 0.5rem 0;
-      }
-      h1,
-      .brand-label {
-        font-family: "Montserrat", "Helvetica Neue", Helvetica, Arial,
-          sans-serif;
       }
 
       /* ===== Layout ===== */
@@ -225,7 +221,6 @@
         fill: none;
       }
       .topbar-title {
-        font-family: 'Inter', system-ui, sans-serif;
         color: #132039;
         text-align: left;
       }


### PR DESCRIPTION
## Summary
- Load Montserrat from Google Fonts and use it as the primary typeface.
- Remove heading-specific font overrides so headers inherit the global font.
- Clean up leftover Inter font reference in the topbar style.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0a197921483278adc530cfa068efa