### PR TITLE
fix: inherit global font for topbar title

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,6 @@
         fill: none;
       }
       .topbar-title {
-        font-family: 'Inter', system-ui, sans-serif;
         color: #132039;
         text-align: left;
       }


### PR DESCRIPTION
## Summary
- ensure topbar header title inherits site-wide Montserrat by removing Inter override

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b0a19a71548327b7ac15c7ca6820ad