### PR TITLE
Allow topbar to expand for long titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       .app {
         display: grid;
         grid-template-columns: var(--sidebar) 1fr;
-        grid-template-rows: 56px 1fr;
+        grid-template-rows: minmax(56px, auto) 1fr;
         height: 100vh;
       }
       .sidebar {


### PR DESCRIPTION
## Summary
- let the top bar row expand by using `minmax(56px, auto)` so long titles are fully visible

## Testing
- `npm test` *(fails: Missing script: "test")*
- Headless browser check for top bar height


------
https://chatgpt.com/codex/tasks/task_e_68b0a48db3b083279031b3a3840c3e4b