### PR TITLE
Adjust topbar padding for better spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         grid-column: 2;
         display: flex;
         align-items: center;
-        padding: 0 18px;
+        padding: 8px 18px 0;
         background: #fff;
         box-shadow: var(--shadow);
         position: sticky;


### PR DESCRIPTION
## Summary
- Add top padding to `.topbar` in `index.html` so the title and subtitle sit lower while keeping existing styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0a6ca21d48327b4d6a9922aa279e5