### PR TITLE
Tighten spacing in topbar text

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
         font-size: 1.875rem;
         font-weight: 700;
         letter-spacing: -0.015em;
-        margin-bottom: 12px; /* ≈ mb-3 */
+        margin-bottom: 8px; /* ≈ mb-2 */
       }
       .topbar-subtitle {
         font-size: 0.875rem;
@@ -240,7 +240,7 @@
         font-weight: 400;
         line-height: 1.5;
         max-width: 600px;
-        margin-top: 4px;
+        margin-top: 0;
         text-align: left;
       }
       .topbar-right {


### PR DESCRIPTION
## Summary
- reduce `.topbar-title .title` bottom margin for smaller title gap
- remove top margin on `.topbar-subtitle` to bring subtitle closer

## Testing
- `npm start` (served page and manually inspected via curl)

------
https://chatgpt.com/codex/tasks/task_e_68b0a6c713908327831ed8441da6b303