### PR TITLE
Shorten Performance Management nav label

### DIFF
--- a/index.html
+++ b/index.html
@@ -883,7 +883,7 @@
             <svg class="ico" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75"/>
             </svg>
-            <span class="label">Performance Management</span>
+            <span class="label">Performance Mgmt</span>
           </a>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- Use abbreviated label "Performance Mgmt" for performance-management link in Admin Center

## Testing
- `npm start`
- `curl -s http://localhost:5000/ | grep -n 'Performance Mgmt' -n`


------
https://chatgpt.com/codex/tasks/task_e_68b0b0a7435083279d6f04d64fbf2530