### PR TITLE
Allow CTA buttons to wrap within course cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -690,15 +690,15 @@
 .course-grid .card{ display:flex; flex-direction:column; height:100%; }
 
 /* one row for actions, pinned to bottom */
-.btn-row{ display:flex; gap:10px; }
+.btn-row{ display:flex; gap:10px; flex-wrap:wrap; }
+.btn-row .cta{ flex:1 1 calc(50% - 5px); min-width:0; }
 .card-action{ margin-top:auto; padding-top:12px; }
 
 /* shared button base */
 .cta{
   display:inline-flex; align-items:center; justify-content:center;
   height:44px; padding:0 24px; border-radius:12px; font-weight:700;
-  text-decoration:none; white-space:nowrap;      /* prevent wrapping */
-  flex:1;                                        /* equal widths */
+  text-decoration:none;
   background:var(--primary); color:#fff; border:3px solid var(--accent-yellow);
 }
 .cta:hover{


### PR DESCRIPTION
## Summary
- Allow course card action buttons to wrap by enabling flex wrapping on the button row
- Let buttons shrink and share space with flexible widths
- Remove nowrap restriction so CTA text can wrap as needed

## Testing
- `npm test` *(fails: Missing script "test")*
- `node test_layout.js` (viewport widths 320, 600, 1024: buttons inside card -> true)

------
https://chatgpt.com/codex/tasks/task_e_68b0b93dc018832790b60d0961325ad8