### PR TITLE
Align certification header styling with card titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,6 +362,11 @@
       }
       .enablement-objectives-header {
         white-space: nowrap;
+        font-size: 16px;
+        font-weight: 700;
+        color: inherit;
+        padding: 0 0 10px 0;
+        border-bottom: none;
       }
       .enablement-objectives .category {
         font-weight: 700;


### PR DESCRIPTION
## Summary
- Style certificate section headers to match card title typography

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0b8e5875883278059ce89f064e744