### PR TITLE
fix: prevent button text wrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -696,7 +696,7 @@
 
 /* one row for actions, pinned to bottom */
 .btn-row{ display:flex; gap:10px; flex-wrap:wrap; }
-.btn-row .cta{ flex:1 1 calc(50% - 5px); min-width:0; }
+.btn-row .cta{ flex:1 1 calc(50% - 5px); min-width:0; white-space:nowrap; }
 .card-action{ margin-top:auto; padding-top:12px; }
 
 /* shared button base */
@@ -711,7 +711,7 @@
   color:var(--primary);
   border:3px solid var(--accent-yellow);
 }
-.cta.cta-sm{ font-size:14px; height:36px; padding:0 18px; }
+.cta.cta-sm{ font-size:12px; height:36px; padding:0 16px; }
 .cta.overview{background:var(--white);color:var(--primary);border:3px solid var(--accent-yellow);}
 .cta.overview:hover{background:var(--accent-yellow);color:var(--primary);border:3px solid var(--accent-yellow);}
 /* --- Content Center --- */


### PR DESCRIPTION
## Summary
- avoid wrapping CTA text by adding `white-space: nowrap`
- shrink small CTAs to 12px font and adjust padding to maintain height

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm start` then `curl -s http://localhost:5000/ | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b0bc6cba6483279b2172d7eff8483b