### PR TITLE
Ensure Smart Suggestions label doesn't wrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,6 +373,7 @@
       }
       .enablement-objectives tr.smart .category {
         color: var(--accent-yellow);
+        white-space: nowrap;
       }
       .enablement-objectives tr.smart {
         background: none;


### PR DESCRIPTION
## Summary
- Prevent wrapping of Smart Suggestions category label in Enablement Objectives

## Testing
- `npm test`
- `node -e "const {JSDOM} = require('jsdom'); const fs=require('fs'); const html=fs.readFileSync('index.html','utf-8'); const dom=new JSDOM(html); const el=dom.window.document.querySelector('.enablement-objectives tr.smart .category'); console.log('Computed white-space:', dom.window.getComputedStyle(el).whiteSpace);"`


------
https://chatgpt.com/codex/tasks/task_e_68b104deaf448327adbcf92dbf1c5521