### PR TITLE
Hide subtitle on non-home pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,6 +243,15 @@
         margin-top: 0;
         text-align: left;
       }
+      body:not(.home-view) .topbar-subtitle {
+        display: none;
+      }
+      body:not(.home-view) .topbar-title .title {
+        margin-bottom: 0;
+      }
+      body:not(.home-view) .topbar {
+        padding-bottom: 8px;
+      }
       .topbar-right {
         margin-left: auto;
         display: flex;
@@ -881,7 +890,7 @@
 
       </style>
     </head>
-  <body>
+  <body class="home-view">
     <div class="app">
       <!-- Sidebar -->
       <aside class="sidebar">
@@ -1717,6 +1726,7 @@
 
       const pages = document.querySelectorAll(".page");
       function show(pageId) {
+        document.body.classList.toggle("home-view", pageId === "home");
         pages.forEach((p) => p.classList.toggle("active", p.id === pageId));
         document
           .querySelectorAll(".nav a, .admin-link")


### PR DESCRIPTION
## Summary
- Hide topbar subtitle and shrink header outside home page
- Toggle `home-view` class based on current page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1127facc083278fcaf89c427e4211